### PR TITLE
feat: add Impressum page

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -31,7 +31,27 @@
     "by": "von"
   },
   "footer": {
-    "built_with": "Gebaut mit"
+    "built_with": "Gebaut mit",
+    "impressum": "Impressum"
+  },
+  "impressum": {
+    "title": "Impressum",
+    "heading": "Impressum",
+    "subheading": "Angaben gemäß § 5 DDG",
+    "name": "Gregor Krykon",
+    "brand": "922-Studio",
+    "address_line1": "Bajuwarenstraße 8",
+    "address_line2": "85567 Grafing bei München",
+    "address_country": "Deutschland",
+    "email": "gregor.krykon@922-studio.com",
+    "contact_label": "Kontakt",
+    "liability_heading": "Haftung für Inhalte",
+    "liability_text": "Als Diensteanbieter sind wir gemäß § 7 Abs. 1 DDG für eigene Inhalte auf diesen Seiten nach den allgemeinen Gesetzen verantwortlich. Nach §§ 8 bis 10 DDG sind wir als Diensteanbieter jedoch nicht verpflichtet, übermittelte oder gespeicherte fremde Informationen zu überwachen oder nach Umständen zu forschen, die auf eine rechtswidrige Tätigkeit hinweisen.",
+    "dispute_heading": "Streitschlichtung",
+    "dispute_text": "Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit:",
+    "dispute_link_text": "https://ec.europa.eu/consumers/odr/",
+    "dispute_note": "Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.",
+    "back": "Zurück zur Startseite"
   },
   "theme": {
     "toggle_dark": "Dunkelmodus umschalten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,7 +31,27 @@
     "by": "by"
   },
   "footer": {
-    "built_with": "Built with"
+    "built_with": "Built with",
+    "impressum": "Legal Notice"
+  },
+  "impressum": {
+    "title": "Legal Notice",
+    "heading": "Legal Notice",
+    "subheading": "Information pursuant to § 5 DDG (German Digital Services Act)",
+    "name": "Gregor Krykon",
+    "brand": "922-Studio",
+    "address_line1": "Bajuwarenstraße 8",
+    "address_line2": "85567 Grafing bei München",
+    "address_country": "Germany",
+    "email": "gregor.krykon@922-studio.com",
+    "contact_label": "Contact",
+    "liability_heading": "Liability for Content",
+    "liability_text": "As a service provider, we are responsible for our own content on these pages in accordance with § 7 (1) DDG under general law. According to §§ 8 to 10 DDG, however, we are not obligated as a service provider to monitor transmitted or stored third-party information or to investigate circumstances that indicate illegal activity.",
+    "dispute_heading": "Dispute Resolution",
+    "dispute_text": "The European Commission provides a platform for online dispute resolution (ODR):",
+    "dispute_link_text": "https://ec.europa.eu/consumers/odr/",
+    "dispute_note": "We are not willing or obligated to participate in dispute resolution proceedings before a consumer arbitration board.",
+    "back": "Back to Homepage"
   },
   "theme": {
     "toggle_dark": "Toggle dark mode",

--- a/src/app/[locale]/impressum/page.tsx
+++ b/src/app/[locale]/impressum/page.tsx
@@ -1,0 +1,104 @@
+import type {Metadata} from 'next';
+import {setRequestLocale} from 'next-intl/server';
+import {getTranslations} from 'next-intl/server';
+import {routing} from '@/i18n/routing';
+import {MapPin, Mail} from 'lucide-react';
+
+type Props = {
+  params: Promise<{locale: string}>;
+};
+
+export async function generateMetadata({params}: Props): Promise<Metadata> {
+  const {locale} = await params;
+  const t = await getTranslations({locale, namespace: 'impressum'});
+
+  return {
+    title: `${t('title')} — 922-Studio`,
+    description: t('subheading'),
+    robots: {index: true, follow: true},
+  };
+}
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({locale}));
+}
+
+export default async function ImpressumPage({params}: Props) {
+  const {locale} = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations({locale, namespace: 'impressum'});
+
+  return (
+    <section className="px-6 py-20">
+      <div className="mx-auto max-w-2xl">
+        <h1 className="text-center font-heading text-3xl font-bold sm:text-4xl">
+          {t('heading')}
+        </h1>
+        <p className="mt-3 text-center text-text-muted">{t('subheading')}</p>
+
+        <div className="mt-12 rounded-2xl border border-border bg-surface p-6 sm:p-8">
+          <div className="text-center">
+            <p className="font-heading text-xl font-semibold text-text-primary">{t('name')}</p>
+            <p className="mt-1 text-sm font-medium text-text-muted">{t('brand')}</p>
+          </div>
+
+          <div className="my-6 border-t border-border" />
+
+          <div className="grid gap-6 sm:grid-cols-2">
+            <div className="flex gap-3">
+              <MapPin size={16} className="mt-0.5 shrink-0 text-text-muted" />
+              <div className="text-sm leading-relaxed text-text-secondary">
+                <p>{t('address_line1')}</p>
+                <p>{t('address_line2')}</p>
+                <p>{t('address_country')}</p>
+              </div>
+            </div>
+            <div className="flex gap-3">
+              <Mail size={16} className="mt-0.5 shrink-0 text-text-muted" />
+              <div>
+                <p className="text-xs text-text-muted">{t('contact_label')}</p>
+                <a
+                  href={`mailto:${t('email')}`}
+                  className="text-sm text-text-secondary transition-colors hover:text-text-primary"
+                >
+                  {t('email')}
+                </a>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-12 space-y-8">
+          <div>
+            <h2 className="font-heading text-lg font-semibold text-text-primary">
+              {t('liability_heading')}
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-text-secondary">
+              {t('liability_text')}
+            </p>
+          </div>
+
+          <div>
+            <h2 className="font-heading text-lg font-semibold text-text-primary">
+              {t('dispute_heading')}
+            </h2>
+            <div className="mt-3 space-y-2 text-sm leading-relaxed text-text-secondary">
+              <p>
+                {t('dispute_text')}{' '}
+                <a
+                  href="https://ec.europa.eu/consumers/odr/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline transition-colors hover:text-text-primary"
+                >
+                  {t('dispute_link_text')}
+                </a>
+              </p>
+              <p>{t('dispute_note')}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import {Github} from 'lucide-react';
 import {useTranslations} from 'next-intl';
+import {Link} from '@/i18n/navigation';
 
 export function Footer() {
   const t = useTranslations('footer');
@@ -24,7 +25,13 @@ export function Footer() {
           {' & '}
           <a href="https://tailwindcss.com" target="_blank" rel="noopener noreferrer" className="underline hover:text-text-secondary">Tailwind CSS</a>
         </p>
-        <p>&copy; 2026 922-Studio</p>
+        <div className="flex items-center gap-3">
+          <p>&copy; 2026 922-Studio</p>
+          <span className="text-border">·</span>
+          <Link href="/impressum" className="underline transition hover:text-text-secondary">
+            {t('impressum')}
+          </Link>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- Adds `/impressum` route under `[locale]` for both `en` and `de` locales
- Legal content per § 5 DDG: Gregor Krykon, Bajuwarenstraße 8, 85567 Grafing bei München
- Footer updated with locale-aware `Link` to `/impressum` (Legal Notice / Impressum)

## Test plan
- [ ] `/en/impressum` and `/de/impressum` render correctly
- [ ] Footer link visible on all pages, correct text per locale
- [ ] Static build passes (`generateStaticParams` covers both locales)
- [ ] CI green