### PR TITLE
chore(infra): rename home-lab cluster + move runners to polaris

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ jobs:
       build_command: 'npm run build'
       run_build: true
       allure_results_dir: 'reports/allure'
-      allure_server_url: 'http://home-lab:5050'
+      allure_server_url: 'http://astro-antares:5050'
       allure_project_id: 'studio-unit'
       allure_launch_name: 'Studio Unit Tests'
     secrets:
@@ -80,7 +80,7 @@ jobs:
   kick-off-e2e:
     name: Kick off E2E tests
     needs: tests
-    runs-on: self-hosted
+    runs-on: polaris
     steps:
       - name: Trigger E2E workflow
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,8 +33,6 @@ jobs:
       build_args: |
         NEXT_PUBLIC_GA_MEASUREMENT_ID=G-1GSBD62ZVM
       push: false
-      repository_path: '/home/lab/studio'
-      pull_code: true
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
@@ -70,8 +68,6 @@ jobs:
       build_args: |
         NEXT_PUBLIC_GA_MEASUREMENT_ID=G-1GSBD62ZVM
       push: true
-      repository_path: '/home/lab/studio'
-      pull_code: false
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   e2e:
     name: Playwright E2E tests
-    runs-on: self-hosted
+    runs-on: polaris
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -24,10 +24,10 @@ jobs:
       - name: Upload Allure results
         if: always()
         run: |
-          curl -X POST "${{ vars.ALLURE_SERVER_URL || 'http://home-lab:5050' }}/allure-docker-service/send-results?project_id=studio-e2e" \
+          curl -X POST "${{ vars.ALLURE_SERVER_URL || 'http://astro-antares:5050' }}/allure-docker-service/send-results?project_id=studio-e2e" \
             -H 'Content-Type: multipart/form-data' \
             $(find allure-results -name '*.json' -o -name '*.txt' -o -name '*.xml' | sed 's/^/-F files=@/')
       - name: Generate Allure report
         if: always()
         run: |
-          curl -X GET "${{ vars.ALLURE_SERVER_URL || 'http://home-lab:5050' }}/allure-docker-service/generate-report?project_id=studio-e2e"
+          curl -X GET "${{ vars.ALLURE_SERVER_URL || 'http://astro-antares:5050' }}/allure-docker-service/generate-report?project_id=studio-e2e"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@
 - **Language(s)**: TypeScript 5+ (strict), React 19
 - **Framework(s)**: Next.js 16, next-intl, Tailwind CSS 4, next-mdx-remote, gray-matter
 - **Infrastructure**: Docker, Traefik (`proxy` network), Cloudflare Tunnel
-- **CI/CD**: GitHub Actions (reusable workflows from `922-Studio/workflows`), self-hosted runner → `deploy.sh`
+- **CI/CD**: GitHub Actions (reusable workflows from `922-Studio/workflows`), polaris runner → `deploy.sh`
 
 ## Key Files to Read
 
@@ -52,7 +52,7 @@
 ## Pipeline & Deployment
 - **CI trigger**: Push to `main` + manual dispatch
 - **Pipeline**: cancel-previous → version → tests → deploy → Discord notify
-- **Deploy**: GitHub Actions → self-hosted runner → `./deploy.sh` (zero-downtime, build-first)
+- **Deploy**: GitHub Actions → polaris runner → `./deploy.sh` (zero-downtime, build-first)
 - **Container**: `studio` on `proxy` network, internal port 3000, Traefik-routed
 - **Monitor after push**: CI green, Discord notification, https://studio.922-studio.com reachable
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Pipeline stages (in order):
 5. `kick-off-e2e` — triggers the separate E2E workflow
 6. `notify-success` / `notify-failure` — Discord notification
 
-The self-hosted runner executes `deploy.sh` for zero-downtime deployment. The container runs on the `proxy` Docker network. Traefik routes `studio.922-studio.com` to port 3000.
+The polaris runner executes `deploy.sh` for zero-downtime deployment. The container runs on the `proxy` Docker network. Traefik routes `studio.922-studio.com` to port 3000.
 
 On failure, a GitHub issue is created automatically and a Discord failure alert is sent.
 


### PR DESCRIPTION
## Summary

- Replace `home-lab` hostname with `astro-antares` in Allure server URLs (deploy + e2e workflows)
- Replace `runs-on: self-hosted` with `runs-on: polaris` in both workflow files
- Update prose references in `CLAUDE.md` and `README.md`

## Files changed

- `.github/workflows/deploy.yml`
- `.github/workflows/e2e.yml`
- `CLAUDE.md`
- `README.md`