### PR TITLE
fix(test): default unit-test script to single-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint",
     "test": "playwright test",
     "test:install": "playwright install --with-deps chromium",
-    "test:unit": "vitest",
+    "test:unit": "vitest run",
+    "test:unit:watch": "vitest",
     "test:unit:ci": "vitest run",
     "test:coverage": "vitest run --coverage"
   },


### PR DESCRIPTION
## Summary

- `test:unit` changed from `vitest` (watch mode) to `vitest run` (single-run)
- New `test:unit:watch` alias added for interactive/watch use
- `test:unit:ci` and all other scripts left untouched

## Why

Bare `vitest` spawns a long-lived worker pool in watch mode. When the controlling process is killed, those workers reparent to launchd and accumulate over time, consuming memory. Making `test:unit` single-run by default eliminates this leak while `test:unit:watch` preserves interactive use.