### PR TITLE
ci(deploy): own deployment via deploy-docker, retire Watchtower

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,6 +77,22 @@ jobs:
       REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
       PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
 
+  deploy-prod:
+    name: Deploy prod to antares
+    needs: [push-prod]
+    uses: 922-Studio/workflows/.github/workflows/deploy-docker.yml@main
+    with:
+      docker_compose_file: docker-compose.deploy.yaml
+      service_name: studio
+      image: registry.922-studio.com/studio:prod
+      deploy_target: antares
+      environment: prod
+      env_file_source: /home/lab/studio/.env
+    secrets:
+      PAT_GITHUB: ${{ secrets.PAT_GITHUB }}
+      REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+      REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+
   kick-off-e2e:
     name: Kick off E2E tests
     needs: tests
@@ -91,11 +107,11 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT_GITHUB }}
 
   create-issue:
-    needs: [tests, push-prod]
-    if: ${{ !cancelled() && (needs.tests.result == 'failure' || needs.push-prod.result == 'failure') }}
+    needs: [tests, push-prod, deploy-prod]
+    if: ${{ !cancelled() && (needs.tests.result == 'failure' || needs.push-prod.result == 'failure' || needs.deploy-prod.result == 'failure') }}
     uses: 922-Studio/workflows/.github/workflows/create-issue.yml@main
     with:
-      job_name: 'build / tests / push'
+      job_name: 'build / tests / push / deploy'
       workflow_status: 'failure'
       repository_name: '${{ github.repository }}'
       branch_name: '${{ github.ref_name }}'
@@ -108,8 +124,8 @@ jobs:
 
   notify-success:
     name: Discord notification (success)
-    needs: [version, push-prod]
-    if: ${{ !cancelled() && needs.push-prod.result == 'success' }}
+    needs: [version, deploy-prod]
+    if: ${{ !cancelled() && needs.deploy-prod.result == 'success' }}
     uses: 922-Studio/workflows/.github/workflows/send-notification.yml@main
     with:
       enable_email: false
@@ -125,8 +141,8 @@ jobs:
 
   notify-failure:
     name: Discord notification (failure)
-    needs: [tests, push-prod, create-issue]
-    if: ${{ !cancelled() && (needs.tests.result == 'failure' || needs.push-prod.result == 'failure') }}
+    needs: [tests, push-prod, deploy-prod, create-issue]
+    if: ${{ !cancelled() && (needs.tests.result == 'failure' || needs.push-prod.result == 'failure' || needs.deploy-prod.result == 'failure') }}
     uses: 922-Studio/workflows/.github/workflows/send-notification.yml@main
     with:
       enable_email: false

--- a/docker-compose.deploy.yaml
+++ b/docker-compose.deploy.yaml
@@ -12,8 +12,6 @@ services:
       retries: 5
       start_period: 15s
     labels:
-      # Watchtower: auto-update this container
-      - "com.centurylinklabs.watchtower.enable=true"
       # Traefik routing
       - "traefik.enable=true"
       - "traefik.http.routers.studio.rule=Host(`studio.922-studio.com`)"


### PR DESCRIPTION
## Summary

- Add `deploy-prod` job (needs `push-prod`) using `deploy-docker.yml@main` targeting antares with `env_file_source: /home/lab/studio/.env`
- Rewire `create-issue`, `notify-success`, and `notify-failure` to gate on `deploy-prod` instead of `push-prod`
- Remove `com.centurylinklabs.watchtower.enable=true` label from `docker-compose.deploy.yaml` — CI now owns the deploy

## Details

- **service_name**: `studio`
- **image**: `registry.922-studio.com/studio:prod`
- **deploy_target**: `antares`
- **env path**: `/home/lab/studio/.env` — verified present on antares
- Prod-only (no dev branch / dev deploy job — mirrors existing push-prod-only topology)

## Test plan

- [ ] CI passes on this branch (build/tests/push — deploy-prod will not run as this is not `main`)
- [ ] After merge to dev and merge dev→main: verify deploy-prod runs and container updates on antares
- [ ] Confirm Watchtower no longer auto-pulls the studio image