### PR TITLE
fix(ci): correct deploy cancellation scope

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ permissions:
   actions: write
   issues: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.inputs.environment || 'default' }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:
@@ -12,12 +16,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  cancel-previous-runs:
-    uses: 922-Studio/workflows/.github/workflows/cancel-previous-runs.yml@main
-
   version:
     name: Create new version
-    needs: cancel-previous-runs
     uses: 922-Studio/workflows/.github/workflows/versioning.yml@main
     secrets:
       PAT_GITHUB: ${{ secrets.PAT_GITHUB }}


### PR DESCRIPTION
## Summary
- Removes the custom `cancel-previous-runs` job (shared reusable workflow) that only filtered stale runs by branch, ignoring the `environment` dispatch input.
- Adds a native GitHub `concurrency:` group scoped to `${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.inputs.environment || 'default' }}` with `cancel-in-progress: true`.

## Why
The shared `cancel-previous-runs.yml` job polls the Actions API and cancels by branch only, so a `workflow_dispatch` targeting one environment could cancel an in-flight run targeting a different environment on the same ref. GitHub's native concurrency groups handle this correctly and natively, with no custom polling logic needed.

Part of an ecosystem-wide migration off the custom `cancel-previous-runs` reusable workflow onto native `concurrency:` groups across all 922-Studio repos.

## Test plan
- [ ] CI passes on this PR
- [ ] Verify `version` job runs without the removed `needs: cancel-previous-runs` dependency
- [ ] Confirm concurrent dev/prod dispatches on the same branch no longer cancel each other